### PR TITLE
Add Russian phonetic keyboard layout

### DIFF
--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/extension.json
@@ -269,6 +269,12 @@
         "direction": "ltr"
       },
       {
+        "id": "yashert_russian",
+        "label": "Russian (ЯШЕРТЫ)",
+        "authors": [ "leekery" ],
+        "direction": "ltr"
+      },
+      {
         "id": "jcuken_ukrainian",
         "label": "Ukrainian (ЙЦУКЕН)",
         "authors": [ "williamtheaker", "33kk" ],

--- a/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/yashert_russian.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.layouts/layouts/characters/yashert_russian.json
@@ -1,0 +1,39 @@
+[
+  [
+    { "$": "auto_text_key", "code": 1103, "label": "я" },
+    { "$": "auto_text_key", "code": 1096, "label": "ш" },
+    { "$": "auto_text_key", "code": 1077, "label": "е" },
+    { "$": "auto_text_key", "code": 1088, "label": "р" },
+    { "$": "auto_text_key", "code": 1090, "label": "т" },
+    { "$": "auto_text_key", "code": 1099, "label": "ы" },
+    { "$": "auto_text_key", "code": 1091, "label": "у" },
+    { "$": "auto_text_key", "code": 1080, "label": "и" },
+    { "$": "auto_text_key", "code": 1086, "label": "о" },
+    { "$": "auto_text_key", "code": 1087, "label": "п" },
+    { "$": "auto_text_key", "code": 1101, "label": "э" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1072, "label": "а" },
+    { "$": "auto_text_key", "code": 1089, "label": "с" },
+    { "$": "auto_text_key", "code": 1076, "label": "д" },
+    { "$": "auto_text_key", "code": 1092, "label": "ф" },
+    { "$": "auto_text_key", "code": 1075, "label": "г" },
+    { "$": "auto_text_key", "code": 1095, "label": "ч" },
+    { "$": "auto_text_key", "code": 1081, "label": "й" },
+    { "$": "auto_text_key", "code": 1082, "label": "к" },
+    { "$": "auto_text_key", "code": 1083, "label": "л" },
+    { "$": "auto_text_key", "code": 1078, "label": "ж" },
+    { "$": "auto_text_key", "code": 1097, "label": "щ" }
+  ],
+  [
+    { "$": "auto_text_key", "code": 1079, "label": "з" },
+    { "$": "auto_text_key", "code": 1093, "label": "х" },
+    { "$": "auto_text_key", "code": 1094, "label": "ц" },
+    { "$": "auto_text_key", "code": 1074, "label": "в" },
+    { "$": "auto_text_key", "code": 1073, "label": "б" },
+    { "$": "auto_text_key", "code": 1085, "label": "н" },
+    { "$": "auto_text_key", "code": 1084, "label": "м" },
+    { "$": "auto_text_key", "code": 1100, "label": "ь" },
+    { "$": "auto_text_key", "code": 1102, "label": "ю" }
+  ]
+]

--- a/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
+++ b/app/src/main/assets/ime/keyboard/org.florisboard.localization/extension.json
@@ -452,6 +452,15 @@
       }
     },
     {
+      "languageTag": "ru",
+      "composer": "org.florisboard.composers:appender",
+      "currencySet": "org.florisboard.currencysets:russian_ruble",
+      "popupMapping": "org.florisboard.localization:ru",
+      "preferred": {
+        "characters": "org.florisboard.layouts:yashert_russian"
+      }
+    },
+    {
       "languageTag": "rue",
       "composer": "org.florisboard.composers:appender",
       "currencySet": "org.florisboard.currencysets:euro",


### PR DESCRIPTION
Closes #302

## Summary

* Add a ЯШЕРТЫ Russian phonetic layout for typing Cyrillic with QWERTY muscle memory.
* Register it as `Russian (ЯШЕРТЫ)` and expose it as a second Russian subtype preset.
* Reuse the existing Russian popup mapping, keeping `ё` and `ъ` available through long presses.

## Validation

* Parsed all affected JSON files.
* Verified the 11/11/9 row structure, 31 unique letters, and matching Unicode key codes.
* Verified the layout and subtype registrations.
