### PR TITLE
Suggest French accents from base-letter prefixes

### DIFF
--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/DictFold.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/DictFold.kt
@@ -16,12 +16,14 @@
 
 package dev.patrickgold.florisboard.ime.nlp.latin
 
+import java.text.Normalizer
+
 /**
  * How a typed word is reduced to the key it is looked up under (issue #265).
  *
- * For most languages this is what it has always been — lowercasing — and [foldKey] returns exactly what
- * `word.lowercase()` used to return, so nothing about English, German or the other 33 dictionaries
- * changes.
+ * For most languages this is what it has always been — lowercasing. French additionally removes
+ * diacritics and expands its common ligatures, so an unaccented prefix still reaches its dictionary
+ * spelling: `ho` finds `hôte`, and `oeu` finds `œuvre`.
  *
  * Arabic script needs more. A reader sees مدرسة and مَدْرَسَة as one word, and writers use أ إ آ and ا
  * interchangeably because only ا sits on the base keyboard — the others hide behind a long press. Left
@@ -64,20 +66,41 @@ package dev.patrickgold.florisboard.ime.nlp.latin
 object DictFold {
     /** Languages written in the Arabic script, using [foldArabic] instead of a plain lowercase. */
     private val ARABIC_SCRIPT = setOf("ar", "fa", "ur", "ckb")
+    /** French accents sit behind long presses, so completion matches their base-letter spelling too. */
+    private const val FRENCH = "fr"
 
     /**
-     * Whether [lang] folds to something other than its lowercase form. Callers use this to skip building
-     * the extra fold→surface indices for the languages that don't need them, so the memory and the code
-     * path for English and the rest stay exactly as they were.
+     * Whether [lang] folds to something other than its lowercase form. Callers use this to skip folded
+     * lookup/index work for the languages that don't need it, so English and the rest stay on their
+     * original code path.
      */
-    fun hasNonTrivialFold(lang: String): Boolean = lang in ARABIC_SCRIPT
+    fun hasNonTrivialFold(lang: String): Boolean = lang in ARABIC_SCRIPT || lang == FRENCH
+
+    /** Only Arabic needs every surface form retained for its spelling-restoration suggestions. */
+    fun hasRestorationVariants(lang: String): Boolean = lang in ARABIC_SCRIPT
 
     /**
      * The dictionary key for [word] in [lang]. Both the stored words and the typed word go through this,
      * so the two always meet.
      */
-    fun foldKey(lang: String, word: String): String =
-        if (lang in ARABIC_SCRIPT) foldArabic(word) else word.lowercase()
+    fun foldKey(lang: String, word: String): String = when {
+        lang in ARABIC_SCRIPT -> foldArabic(word)
+        lang == FRENCH -> foldFrench(word)
+        else -> word.lowercase()
+    }
+
+    /**
+     * Reduces French accents to their base letters for dictionary lookup. NFD covers acute, grave,
+     * circumflex, diaeresis and cedilla whether the input arrived precomposed or as a combining mark;
+     * `œ` and `æ` need their conventional two-letter expansions because Unicode does not decompose them.
+     */
+    fun foldFrench(word: String): String = Normalizer.normalize(word, Normalizer.Form.NFD)
+        .asSequence()
+        .filter { it.category != CharCategory.NON_SPACING_MARK }
+        .joinToString("")
+        .lowercase()
+        .replace("œ", "oe")
+        .replace("æ", "ae")
 
     /**
      * Reduce an Arabic-script word to its lookup key. Also lowercases, because Arabic text is full of

--- a/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
+++ b/app/src/main/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/LatinLanguageProvider.kt
@@ -185,7 +185,7 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
     // frequent words first and stop early. Built lazily from the word data and cached.
     private val rankedWordsByLang = guardedByLock { mutableMapOf<String, List<String>>() }
 
-    // Fold keys aligned with rankedWordsByLang, for the languages where the two differ (issue #265).
+    // Fold keys aligned with rankedWordsByLang, for languages whose lookup spelling differs (issue #265).
     private val rankedFoldKeysByLang = guardedByLock { mutableMapOf<String, List<String>>() }
 
     // Languages that ship a bundled ime/dict/<lang>.json (currently just English), listed once.
@@ -300,9 +300,9 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
             appContext.assets.readText("ime/dict/${lang}_bigrams.txt")
         }
         val map = HashMap<String, Long>(45_000)
-        // The file stores "w1 w2" lowercased; the lookup happens in fold space, so an Arabic-script
-        // language has to fold the key too or no pair would ever match. Folding the whole key at once is
-        // safe — the fold passes the separating space through untouched.
+        // The file stores "w1 w2" lowercased; the lookup happens in fold space, so a language with
+        // non-trivial folding has to fold the key too or no pair would ever match. Folding the whole key
+        // at once is safe — each fold passes the separating space through untouched.
         val folds = DictFold.hasNonTrivialFold(lang)
         text.lineSequence().forEach { line ->
             val tab = line.indexOf('\t')
@@ -348,9 +348,8 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
      * a plain lowercase and prefix matching can compare the words directly.
      *
      * Prefix completion is the one place that works on the *stored* spellings rather than the folded index,
-     * so an Arabic writer typing ان would otherwise get no completions at all — أنا and أنت do not start
-     * with what they typed. Precomputed once per language because folding 79,000 words on every keystroke
-     * is not an option.
+     * so an Arabic writer typing ان or a French writer typing ho would otherwise miss أنا and hôte.
+     * Precomputed once per language because folding 79,000 words on every keystroke is not an option.
      */
     private suspend fun rankedFoldKeysFor(subtype: Subtype, ranked: List<String>): List<String>? {
         val lang = dictLangFor(subtype)?.takeIf { DictFold.hasNonTrivialFold(it) } ?: return null
@@ -448,9 +447,9 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
                 val freq = HashMap<String, Int>(data.size)
                 val canonical = HashMap<String, String>(data.size)
                 val alphabet = HashSet<Char>()
-                // Only collected where the fold actually merges spellings, so nothing is paid for the
-                // languages where every key has exactly one form anyway.
-                val forms = if (DictFold.hasNonTrivialFold(lang)) HashMap<String, MutableList<String>>() else null
+                // Only Arabic restores an alternate spelling as a dedicated suggestion. French uses its
+                // fold for prefix matching, but needs neither this large surface-form index nor autocorrect.
+                val forms = if (DictFold.hasRestorationVariants(lang)) HashMap<String, MutableList<String>>() else null
                 for ((word, f) in data) {
                     val key = DictFold.foldKey(lang, word)
                     if ((freq[key] ?: -1) < f) {
@@ -916,7 +915,7 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         // is a recognisable word with a preferred spelling, not a mistake.
         // Length 2 rather than the 3 the German and apostrophe blocks use: Arabic's most-written words are
         // two letters (من، في، ما), and فى → في is exactly the fix being asked for.
-        if (DictFold.hasNonTrivialFold(index.lang) && word.length >= 2) {
+        if (DictFold.hasRestorationVariants(index.lang) && word.length >= 2) {
             val key = index.fold(word)
             val forms = index.formsOf(key)
             if (forms.isNotEmpty() && forms.none { it == word }) {
@@ -1028,7 +1027,7 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
             dm.queryUserDictionary(word, subtype.primaryLocale)
         }.getOrNull().orEmpty()
             .map { it.text.toString() }
-            .filter { it.startsWith(word, ignoreCase = true) }
+            .filter { index.fold(it).startsWith(index.fold(word)) }
             .distinctBy { it.lowercase() }
         var personalTaken = 0
 
@@ -1048,9 +1047,9 @@ class LatinLanguageProvider(context: Context) : SpellingProvider, SuggestionProv
         }
 
         val data = wordDataFor(subtype)
-        // Prefix matching happens on the stored spellings, so an Arabic writer typing ان would find
-        // nothing — أنا does not start with it. Where the fold merges spellings, compare the precomputed
-        // fold keys instead; everywhere else this is the same comparison it always was.
+        // Prefix matching happens on the stored spellings, so an Arabic writer typing ان or a French
+        // writer typing ho would miss أنا and hôte. Where the fold changes the lookup spelling, compare
+        // the precomputed fold keys instead; everywhere else this is the same comparison it always was.
         val ranked = rankedWordsFor(subtype)
         val rankedKeys = rankedFoldKeysFor(subtype, ranked)
         val foldedPrefix = if (rankedKeys != null) index.fold(word) else ""

--- a/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/DictFoldTest.kt
+++ b/app/src/test/kotlin/dev/patrickgold/florisboard/ime/nlp/latin/DictFoldTest.kt
@@ -19,17 +19,17 @@ import kotlin.test.assertTrue
 /**
  * Covers the dictionary key folding (issue #265).
  *
- * Two things matter here and they pull against each other: an Arabic word must reach its entry however
- * the writer spelled it, and every language that already ships a dictionary must fold exactly the way it
- * did before — a change there would silently re-key 33 word lists.
+ * French and Arabic words must reach their entries from the spellings people can easily type, while every
+ * other language that already ships a dictionary must fold exactly the way it did before — a change there
+ * would silently re-key its word list.
  */
 class DictFoldTest {
 
     // --- the languages that must not change -------------------------------------------------------
 
     @Test
-    fun `latin languages still fold to plain lowercase`() {
-        for (lang in listOf("en", "de", "fr", "tr", "vi", "ru", "el", "he")) {
+    fun `other languages still fold to plain lowercase`() {
+        for (lang in listOf("en", "de", "tr", "vi", "ru", "el", "he")) {
             for (word in listOf("Baum", "STRASSE", "don't", "well-known", "Ärmel", "İstanbul", "мир", "Ελλάδα")) {
                 assertEquals(word.lowercase(), DictFold.foldKey(lang, word), "$lang / $word")
             }
@@ -37,13 +37,38 @@ class DictFoldTest {
     }
 
     @Test
-    fun `only arabic script languages fold non-trivially`() {
+    fun `only french and arabic script languages fold non-trivially`() {
         for (lang in listOf("ar", "fa", "ur", "ckb")) {
             assertTrue(DictFold.hasNonTrivialFold(lang), lang)
         }
+        assertTrue(DictFold.hasNonTrivialFold("fr"))
+        assertFalse(DictFold.hasRestorationVariants("fr"))
         for (lang in listOf("en", "de", "he", "fa-IR", "", "hi", "bn", "ta")) {
             assertFalse(DictFold.hasNonTrivialFold(lang), lang)
         }
+    }
+
+    // --- french: base-letter typing reaches accented spellings -----------------------------------
+
+    @Test
+    fun `french accents fold to their base letters`() {
+        assertEquals("hote", DictFold.foldFrench("hôte"))
+        assertEquals("garcon", DictFold.foldFrench("garçon"))
+        assertEquals("eleve", DictFold.foldFrench("élève"))
+        assertEquals("deja", DictFold.foldFrench("de\u0301ja"))
+    }
+
+    @Test
+    fun `french unaccented prefixes match accented dictionary words`() {
+        val prefix = DictFold.foldKey("fr", "ho")
+        assertTrue(DictFold.foldKey("fr", "hôte").startsWith(prefix))
+        assertTrue(DictFold.foldKey("fr", "hôtel").startsWith(prefix))
+    }
+
+    @Test
+    fun `french ligatures fold to their keyboard spelling`() {
+        assertEquals("oeuvre", DictFold.foldFrench("œuvre"))
+        assertEquals("aether", DictFold.foldFrench("æther"))
     }
 
     // --- arabic: marks that carry no meaning ------------------------------------------------------


### PR DESCRIPTION
Summary:
- Make French dictionary lookups accent-insensitive, including decomposed accents and common ligatures.
- Use folded keys for bundled and personal-word prefix suggestions, so ho can offer hôte and hôtel.
- Preserve existing Arabic restoration behavior without adding French autocorrection.

Validation:
- Android unit test DictFoldTest: 18 tests passed.