### PR TITLE
Wear OS: fix Enter not sending in WhatsApp and dictation not landing in Browser (#294)

### DIFF
--- a/wear/src/main/kotlin/net/devemperor/dictate/wear/ime/WearImeService.kt
+++ b/wear/src/main/kotlin/net/devemperor/dictate/wear/ime/WearImeService.kt
@@ -182,7 +182,9 @@ class WearImeService :
         val ic = ic() ?: return
         val action = editorAction()
         if (action != null) {
-            ic.performEditorAction(action)
+            // The action *is* the submit, so the keyboard is done once it lands: the app is already
+            // showing its result, and the opaque input view would otherwise sit on top of it.
+            if (ic.performEditorAction(action)) requestHideSelf(0)
             return
         }
         val multiline = (currentInputEditorInfo?.inputType ?: 0) and
@@ -313,9 +315,11 @@ class WearImeService :
                     ic()?.commitText(text, 1)
                     recordingInfo.value = WearRecordingInfo()
                     dictationState.value = WearDictationState.IDLE
-                    // Dictation is the primary action — once the text is in, get out of the way so the
-                    // user sees their field again instead of a keyboard stuck open over it.
-                    requestHideSelf(0)
+                    // Dictation is the primary action, so getting out of the way is the right default —
+                    // but not over a field that declares a submit action. There the dictation is only
+                    // half the job: hiding steals the ⏎ the user still needs, and the teardown races the
+                    // commit we just made, which Samsung's browser loses the text to entirely (#294).
+                    if (editorAction() == null) requestHideSelf(0)
                 }
             }
         }

--- a/wear/src/main/kotlin/net/devemperor/dictate/wear/ime/WearImeService.kt
+++ b/wear/src/main/kotlin/net/devemperor/dictate/wear/ime/WearImeService.kt
@@ -14,8 +14,11 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.inputmethodservice.InputMethodService
 import android.os.SystemClock
+import android.text.InputType
 import android.util.Log
+import android.view.KeyEvent
 import android.view.View
+import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
@@ -90,7 +93,7 @@ class WearImeService :
         WearSettingsStore.load(applicationContext)
     }
 
-    override fun onStartInputView(info: android.view.inputmethod.EditorInfo?, restarting: Boolean) {
+    override fun onStartInputView(info: EditorInfo?, restarting: Boolean) {
         super.onStartInputView(info, restarting)
         // Opening the keyboard is a good moment to reconcile with the phone: read the latest replicated
         // settings DataItem (accent/provider/key/prompt) and nudge a republish. The cached copy is used
@@ -146,7 +149,7 @@ class WearImeService :
     private val actions = WearImeActions(
         commitText = { text -> ic()?.commitText(text, 1) },
         deleteBackward = { ic()?.deleteSurroundingText(1, 0) },
-        performEnter = { ic()?.commitText("\n", 1) },
+        performEnter = { performEnter() },
         toggleDictation = { toggleDictation() },
         togglePause = { togglePause() },
         cancelDictation = { cancelDictation() },
@@ -154,6 +157,38 @@ class WearImeService :
     )
 
     private fun ic(): InputConnection? = currentInputConnection
+
+    /**
+     * The submit action the focused field declares (SEND / SEARCH / GO / DONE …), or null when it has
+     * none for the IME to fire — either because it declares no action, or because it asked the IME to
+     * leave Enter alone with [EditorInfo.IME_FLAG_NO_ENTER_ACTION].
+     */
+    private fun editorAction(): Int? {
+        val imeOptions = currentInputEditorInfo?.imeOptions ?: return null
+        if (imeOptions and EditorInfo.IME_FLAG_NO_ENTER_ACTION != 0) return null
+        return (imeOptions and EditorInfo.IME_MASK_ACTION).takeUnless {
+            it == EditorInfo.IME_ACTION_NONE || it == EditorInfo.IME_ACTION_UNSPECIFIED
+        }
+    }
+
+    /**
+     * The ⏎ key. Committing a literal newline is the wrong thing for most fields: WhatsApp's compose box
+     * and the browser's search bar declare an *editor action* (SEND / SEARCH) and act on that, never on
+     * "\n", which is why Enter looked dead in those apps (#294). So fire the declared action when there
+     * is one, fall back to a real ENTER key event for fields that want the key press, and only insert a
+     * newline into genuinely multi-line editors.
+     */
+    private fun performEnter() {
+        val ic = ic() ?: return
+        val action = editorAction()
+        if (action != null) {
+            ic.performEditorAction(action)
+            return
+        }
+        val multiline = (currentInputEditorInfo?.inputType ?: 0) and
+            InputType.TYPE_TEXT_FLAG_MULTI_LINE != 0
+        if (multiline) ic.commitText("\n", 1) else sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
+    }
 
     /**
      * Voice-page record button. Tap once to start recording, tap again to stop; on stop the audio is


### PR DESCRIPTION
Fixes #294.

Hi! I really enjoy your apps. I paid for Dictate Wear and it was such a bummer when it
didn't work on my watch, I really was looking forward to have something like this. I know my way around adb tooling and had a feeling the fix might be simple,
so I vibed my way through it, and this is what I ended up with.

## What was wrong

Two problems I described earlier turned out to be the same story.

**Enter (from the numpad)  didn't submit.** `performEnter` committed a literal `"\n"`. Most fields never treat that as a
submit — they declare an editor action in `imeOptions` and act on that instead. So in WhatsApp the
transcript landed in the box and just sat there, and in the Browser the search never ran.

Something that surprised me, and that may not be obvious without a Galaxy Watch (and logcat) in hand: **the field
Dictate binds to is usually not the app's own.** On Wear OS 6 / One UI 8 Watch, WhatsApp and Keep Notes
both go through Samsung's RemoteInput text-entry activity, so the IME sees

```
onStartInputView: pkg=com.samsung.android.honeyboard action=DONE imeOptions=0x6 inputType=0xc041
```

and the app's own window only returns (with `inputType=0x0`, not an editor) once that DONE action
fires. That's why Keep Notes seemed to work while WhatsApp didn't. Samsung Browser is the exception —
a directly bound field declaring `IME_ACTION_SEARCH`.

**Dictated text disappeared in the Browser.** After a transcription the service commits the text and
immediately calls `requestHideSelf(0)`. Over the browser's search field that teardown races the commit
and the text is dropped — the same field accepts keypad input fine, where no hide is involved. And even
where the text survived, hiding took away the ⏎ needed to send it.

## What I changed

1. ⏎ fires the field's declared action (SEND / SEARCH / GO / DONE …), falls back to a real
   `KEYCODE_ENTER` when there is none, and commits a newline only for multi-line editors.
   `IME_FLAG_NO_ENTER_ACTION` is respected.
2. The post-dictation auto-hide now only happens when the field has no pending action — unchanged for
   notes-style fields — and the keyboard hides once the action has actually fired, so it isn't left
   sitting opaque over the result.

44 added lines in one file, no UI changes.

## How I tested

Galaxy Watch8 (SM-L330), Wear OS 6.0 / One UI 8.0 Watch, tethered to Dictate on a Galaxy S26 Ultra
(Android 16).

|  | before | after |
| --- | --- | --- |
| WhatsApp | text lands, Enter does nothing | Enter fires DONE, message sends |
| Browser | dictated text never appears | text lands, Enter runs the search |
| Keep Notes | works | still works, still auto-hides |

Important to say, the way to send a transcripted is with the Enter button of the numpad, it is usable but maybe not ideal.

## The part I can't check

I only have my own watch, so I'm blind to how this behaves elsewhere. The risk I'd flag: a field that
declares an action but expects a newline anyway would now submit instead of adding a line. I tried to
guard that with the multi-line and `IME_FLAG_NO_ENTER_ACTION` checks, but a device reporting things
differently could behave differently. If you'd rather shape this another way, I'm happy to re run checks in my watch.

This is my first time contributing to an open source project like this. Hope it helps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBBqERL2Akg9cYDXRaaK7D
